### PR TITLE
Locations with no apid are not sent to server

### DIFF
--- a/TPClient.py
+++ b/TPClient.py
@@ -353,7 +353,7 @@ async def check_locations(ctx: TPContext) -> None:
         else:
             addr = data.offset
 
-        if not addr or not flag:
+        if not addr or not flag or data.code == None:
             # logger.error(f"Invalid location: {location}")
             continue
 


### PR DESCRIPTION
Fixes issue #30 by skipping over locations that have no apid set but have save data.